### PR TITLE
Moving out drainqueue from goroutine

### DIFF
--- a/lambda-extensions/sumologic-extension.go
+++ b/lambda-extensions/sumologic-extension.go
@@ -96,7 +96,7 @@ func processEvents(ctx context.Context) {
 			consumer.FlushDataQueue(ctx)
 			return
 		default:
-			go consumer.DrainQueue(ctx)
+			consumer.DrainQueue(ctx)
 			// This statement will freeze lambda
 			nextResponse, err := nextEvent(ctx)
 			if err != nil {


### PR DESCRIPTION
Based on the discussion with SumoLogic, removing goroutine seems like a good solution for our case.
Will adhoc in sandbox.

@mdsol/enablement 