### PR TITLE
Check interface conversion to not panic

### DIFF
--- a/lambda-extensions/sumoclient/sumoclient.go
+++ b/lambda-extensions/sumoclient/sumoclient.go
@@ -191,8 +191,13 @@ func (s *sumoLogicClient) enhanceLogs(msg responseBody) {
 			if err != nil {
 				item["message"] = strings.TrimSpace(message)
 			} else {
-				for key, value := range jsonMessage.(map[string]interface{}) {
-					item[key] = value
+				jsonMessageMap, ok := jsonMessage.(map[string]interface{})
+				if ok {
+					for key, value := range jsonMessageMap {
+						item[key] = value
+					}
+				} else {
+					item["message"] = strings.TrimSpace(message)
 				}
 			}
 		} else if ok && logType == "platform.report" {


### PR DESCRIPTION
### Background

When a number value is passed to the logger:

```python
logger.info("1.23")
```

the interface conversion fails and raises this error:

> panic: interface conversion: interface {} is float64, not map[string]interface {}

### Changes

logs as JSON only when the conversion succeeds 

@mdsol/enablement 