### PR TITLE
Build ARM64 package

### DIFF
--- a/scripts/zip.sh
+++ b/scripts/zip.sh
@@ -49,7 +49,7 @@ for arch in "${ARCHITECTURES[@]}"; do
   fi
   cd -
 
-  exit 0 # skip deploying layer
+  continue # skip deploying layer
 
   echo "Create lambda Layer from the new ZIP file in the provided AWS_PROFILE aws account."
   if [[ -z "${AWS_PROFILE}" ]]; then


### PR DESCRIPTION
still skip deploying, but to continue to build ARM64 package

@mdsol/architecture-enablement 